### PR TITLE
do not ignore directories ending in .[Cc]ache

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -152,6 +152,7 @@ AppPackages/
 
 # Others
 *.[Cc]ache
+!*.[Cc]ache/
 ClientBin/
 [Ss]tyle[Cc]op.*
 ~$*


### PR DESCRIPTION
Directories ending in .[Cc]ache should not be ignored.

For example:
ProjectName.Cache/ProjectName.Cache.csproj